### PR TITLE
Improve Debian/Ubuntu instruction

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,7 +8,7 @@ MML Compiler (MML to MIDI File Converter)
 
 ## Compiler
 
-- Full (Default) : Delphi7 (Win)
+- Full (Windows only) : Delphi7
 - Commnad line version : Delphi7 / FPC (Free Pascal Compiler)
 
 ## Charset 
@@ -17,51 +17,65 @@ MML Compiler (MML to MIDI File Converter)
 
 ### Compile for FPC (Free Pascal compiler)
 
-- 1. Install FPC
-- 2. Compile
+1. Install FPC
+2. Compile
 
-```
-fpc -Mdelphi -g -gv -vewh csakura.dpr
-    OR
-./make.sh
-```
+    ```sh
+    fpc -Mdelphi -g -gv -vewh csakura.dpr
+        OR
+    ./make.sh
+    ```
 
 ### Compile (Debian, Ubuntu)
 
 1. Install dependencies
 
-```
-sudo apt install libc-dev fp-compiler
-```
+    ```sh
+    sudo apt install libc-dev fp-compiler
+    ```
 
 2. Compile
 
-```
-git clone https://github.com/kujirahand/sakuramml.git
-cd sakuramml
-./make.sh
-```
+    ```sh
+    git clone https://github.com/kujirahand/sakuramml.git
+    cd sakuramml
+    ./make.sh
+    ```
 
 
-### Compile (Linux)
+### Compile (other Linux)
 
-- 1. check CPU
- - 1.1 ``uname -a``
- - 2. Install FPC
-  - 2.1 https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/
-  - 2.2 (ex) wget wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar/download
-  - 2.3 ``tar xvf download``
-  - 2.4 ``cd fpc-3.0.4.x86_64-linux/``
-  - 2.5 ``./install.sh``
-- 3. pull sourcecode
- - 3.1 ``git clone https://github.com/kujirahand/sakuramml.git``
- - 3,2 ``cd sakuramml``
- - 3.3 ``./make.sh``
- - ここまで来れば、警告がいくつか表示される物の、./csakuraという実行ファイルができているはず
+1. Check CPU
+
+    ```sh
+    uname -a
+    ```
+
+2. Install FPC
+
+    - https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/
+
+    ```sh
+    # example
+    wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar/download
+    tar xvf download
+    cd fpc-3.0.4.x86_64-linux/
+    ./install.sh
+    ```
+
+3. Pull sourcecode
+
+    ```
+    git clone https://github.com/kujirahand/sakuramml.git
+    cd sakuramml
+    ./make.sh
+    ```
+
+    ここまで来れば、警告がいくつか表示される物の、./csakuraという実行ファイルができているはず
 
 ### Compile (Raspberry pi)
 
-```
+```sh
 sudo apt-get update
 sudo apt-get install fpc
 git clone https://github.com/kujirahand/sakuramml.git

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,7 +31,7 @@ fpc -Mdelphi -g -gv -vewh csakura.dpr
 1. Install dependencies
 
 ```
-sudo apt install libc-dev fp-compiler nkf
+sudo apt install libc-dev fp-compiler
 ```
 
 2. Compile
@@ -64,7 +64,6 @@ cd sakuramml
 ```
 sudo apt-get update
 sudo apt-get install fpc
-sudo apt-get install nkf
 git clone https://github.com/kujirahand/sakuramml.git
 cd sakuramml
 ./make.sh

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,6 +26,23 @@ fpc -Mdelphi -g -gv -vewh csakura.dpr
 ./make.sh
 ```
 
+### Compile (Debian, Ubuntu)
+
+1. Install dependencies
+
+```
+sudo apt install libc-dev fp-compiler nkf
+```
+
+2. Compile
+
+```
+git clone https://github.com/kujirahand/sakuramml.git
+cd sakuramml
+./make.sh
+```
+
+
 ### Compile (Linux)
 
 - 1. check CPU

--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 fpc -Mdelphi -g -gv -vewh csakura.dpr && \
-  # ./csakura test.mml | nkf -w
-  ./csakura sample/sakura2.mml | nkf -w
+  # ./csakura test.mml | iconv -f cp932
+  ./csakura sample/sakura2.mml | iconv -f cp932
 
 


### PR DESCRIPTION
sakurammlにはお世話になっております。

色々試行錯誤の結果、DebianやUbuntuでなるべく追加パッケージ数を抑えて簡単にコンパイルすることができたのでReadMe.mdに追記しました。

あと、だいたいのLinuxには最初から入ってるiconvがnkfの代わりに（たぶん）なるので置き換えました。

ついでに、ReadMe.mdの整形がおかしかったので直しておきました。

よろしくお願いします。